### PR TITLE
FIX: resolve issue with matplotlib 3.5.1 and set_offsets in plot.py

### DIFF
--- a/tid/plot.py
+++ b/tid/plot.py
@@ -108,7 +108,7 @@ def plot_map(
             scatter.set_color(cm.plasma(nvals))
 
     def init():
-        scatter.set_offsets([])
+        return scatter
 
     ani = animation.FuncAnimation(
         plt.gcf(),


### PR DESCRIPTION
Matplotlib 3.5.1 made [changes to the `set_offsets` method](https://github.com/matplotlib/matplotlib/commit/25ff2ed09ff36596a144d3692f1739b4abe72c7a) which is used in [`plot.py`](https://github.com/tylerni7/missile-tid/blob/252232d5989d267c2794d9d55fb38fe0249f605f/tid/plot.py#L110), specifically to initialise an empty plot ready to be animated. These changes mean one can no longer pass an empty list to `set_offsets`.

The `init` function only needs to return the empty plot object so I have amended it to do exactly this. 

Currently:
- With matplotlib 3.5.0 the `vandenberg.py` demo works.
- With matplotlib 3.5.1 the `vandenberg.py` demo fails with error
```
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```


With the below change `vandenberg.py` works with matplotlib 3.5.1.
