### PR TITLE
Update connections import to Python 3.10 version

### DIFF
--- a/tid/connections.py
+++ b/tid/connections.py
@@ -4,7 +4,7 @@ between satellites and ground stations.
 Things to manage those are stored here
 """
 from __future__ import annotations  # defer type annotations due to circular stuff
-import collections
+import collections.abc as collections
 from functools import cached_property
 from typing import (
     cast,


### PR DESCRIPTION
In Python 3.10, they changed how collections is imported. This fixes it.

For more info: https://stackoverflow.com/questions/69596494/unable-to-import-freegames-python-package-attributeerror-module-collections

This seems backwards compatible with Python 3.6 and 3.7 on my machine (Intel Macbook Pro). 