### PR TITLE
Changed the README and CONTRIBUTING files to include updated install …

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,11 +61,16 @@ Ready to contribute? Here's how to set up `tid` for local development.
 
     $ git clone git@github.com:your_name_here/missile-tid.git
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+3. Install your local copy into a `conda` environment (for example, virtualenv or just in your local environment should
+work too, though some specifics may differ). The commands below follow the instructions in the README:
 
-    $ mkvirtualenv missile-tid
-    $ cd missile-tid/
-    $ python setup.py develop
+    $ sudo apt install gcc g++ libcurl4-openssl-dev libgeos-dev
+    $ conda create --name missiletid python=3.10
+    $ conda activate missiletid
+    $ pip install -r requirements-dev.txt
+    $ pip install -e ./
+    $ conda install pycurl
+    $ pip install --force-reinstall shapely --no-binary shapely
 
 4. Create a branch for local development::
 
@@ -76,10 +81,11 @@ Ready to contribute? Here's how to set up `tid` for local development.
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
     $ flake8 tid tests
-    $ python setup.py test
+    $ # python setup.py test
     $ tox
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   To get flake8 and tox, just pip install them into your virtualenv. (Note that since the refactor, `setup.py` has been removed
+so tests will have to be run separately.)
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -78,14 +78,13 @@ work too, though some specifics may differ). The commands below follow the instr
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+5. When you're done making changes, check that your changes pass flake8 and the tests (using `pytest`), including testing other Python versions with tox::
 
     $ flake8 tid tests
-    $ # python setup.py test
+    $ pytest
     $ tox
 
-   To get flake8 and tox, just pip install them into your virtualenv. (Note that since the refactor, `setup.py` has been removed
-so tests will have to be run separately.)
+   To get flake8 and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@ when they travel through the ionosphere.
 
 ## Setup
 
-Some platform-specific dependencies must be installed first. Once this is done,
-you should be able to install the requirements with
+Some platform-specific dependencies must be installed first. 
 
-`python -m pip install -r requirements.txt`
-
-### Ubuntu (20.04)
+#### Ubuntu (20.04)
 
 If in doubt, check the Dockerfile for an exact build recipe, as that will be 
 based on an Ubuntu image.
@@ -36,6 +33,21 @@ you must have a Python executable that is running on the same arch as the geos b
 you installed using brew. This may mean you have the wrong Anaconda version (`x86_64` vs `arm64`),
 as an example.
 
+## Installing
+
+Once dependencies are installed, you should be able to install the requirements with:
+
+`python -m pip install -r requirements.txt`
+
+For development, use `requirements-dev.txt` instead. After that, install directly from within the repository:
+
+`python -m pip install -e ./`
+
+For the time being one final step is required: manually make a copy of the example config
+file and rename it as `configuration.yml`. The following command should do this:
+
+`cp config/configuration.yml.example config/configuration.yml`
+
 ## Running the demos
 
 There are currently two demos available to produce animations of the TID about an area:
@@ -44,7 +56,15 @@ There are currently two demos available to produce animations of the TID about a
 
 ### Common errors
 
-* If you receive the error: `free(): invalid size` when producing the animation, then you must compile Cartopy from source, and not from a built wheel. Eg: `pip install --upgrade --no-binary shapely shapely==1.8.4`
+* In some cases the version of `pycurl` that is installed from the requirements
+file has a problem where `libffi` is pointing to the wrong version. Reinstalling
+`pycurl` manually via `pip` (or `conda` if using that) without the version specifier
+seems to fix this.
+* If you receive the error: `free(): invalid size` when producing the animation, 
+then you must compile Shapely from source. The command `pip install --force-reinstall 
+shapely --no-binary shapely` should work for this. 
+    * It may be necessary to install `Cython` prior to the shapely reinstall, in which
+        case it can be installed via `pip` or `conda` as usual.
 
 ## Contributing
 


### PR DESCRIPTION
I went through and did an install of the library today and based on that experience I have updated the install documents to reflect all the required steps. One thing that is an issue is that we don't have a `setup.py` file anymore so all documentation based on that is no longer operative, so I've replaced that where possible. In the CONTRIBUTING.rst file there is a step that requires the setup file in order to run tests, and in that case I added a note that the testing step should be "done manually", and added a `#` to comment that line out in the commands.